### PR TITLE
Add --skip-root-check in magento version check

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -67,7 +67,7 @@ set('clear_paths', [
 
 // Check Magento version
 set('magento_version', function (){
-    return run("{{magerun}} sys:info version --root-dir={{release_path}}");
+    return run("{{magerun}} sys:info version --skip-root-check --root-dir={{release_path}}");
 });
 
 # ----- Magento 2 Tasks -------


### PR DESCRIPTION
When running as a root I got the error:
```
It's not recommended to run n98-magerun as root user
```
Outputed for every n98-magerun command. As a result it caused the magento version to crash. 
Adding `--skip-root-check` solved the issue.